### PR TITLE
Feature/make extendable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile 'org.jboss.as:jboss-as-controller-client:7.2.0.Final'
+    testCompile 'junit:junit:4.12'
 }
 
 compileGroovy {

--- a/src/test/groovy/fr/javatic/gradle/jbossController/JBossControllerPluginTest.groovy
+++ b/src/test/groovy/fr/javatic/gradle/jbossController/JBossControllerPluginTest.groovy
@@ -24,7 +24,7 @@ class JBossControllerPluginTest {
     @Test
     public void greeterPluginAddsGreetingTaskToProject() {
         Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'jboss-controller'
+        project.apply plugin: 'fr.javatic.jboss-controller'
 
         project.task('testTask', type: project.JBossController) {
             host = 'localhost'


### PR DESCRIPTION
I ran into problems defining a subclass of the JBossUrlDeployTask class in one of my projects.

The problem is that when you refer to properties inside the task, groovy will use the fields instead of the generated getters. So if I try to overload the getters in my subclass, nothing will happen.

This PR uses getters to access the properties, making the task extensible.